### PR TITLE
CI: Add tag-triggered GitHub Actions release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,111 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'        # 4.7.1 -> stable
+      - '[0-9]+.[0-9]+.[0-9]+.beta'   # 4.7.1.beta -> prerelease
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to build, e.g. 4.7.1 or 4.7.1.beta (build-only, no release)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Parse and validate version
+        id: ver
+        env:
+          RAW_VERSION: ${{ github.event_name == 'push' && github.ref_name || inputs.version }}
+        run: |
+          if [[ "$RAW_VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)(\.beta)?$ ]]; then
+            MAJOR="${BASH_REMATCH[1]}"; MINOR="${BASH_REMATCH[2]}"; PATCH="${BASH_REMATCH[3]}"
+            [[ -n "${BASH_REMATCH[4]}" ]] && PRERELEASE=true || PRERELEASE=false
+          else
+            echo "::error::Version '$RAW_VERSION' must match X.Y.Z or X.Y.Z.beta (e.g. 4.7.1, 4.7.1.beta)"
+            exit 1
+          fi
+          if (( MINOR > 99 || PATCH > 99 )); then
+            echo "::error::minor/patch must be <= 99 to keep versionCode monotonic"
+            exit 1
+          fi
+          # beta-offset scheme: 4.7.1.beta=407010 < 4.7.1=407011
+          if $PRERELEASE; then STABLE=0; else STABLE=1; fi
+          VERSION_CODE=$(( MAJOR*100000 + MINOR*1000 + PATCH*10 + STABLE ))
+          {
+            echo "version_name=$RAW_VERSION"
+            echo "version_code=$VERSION_CODE"
+            echo "prerelease=$PRERELEASE"
+          } >> "$GITHUB_OUTPUT"
+          echo "Building $RAW_VERSION (versionCode=$VERSION_CODE, prerelease=$PRERELEASE)"
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '11'   # Gradle 6.5 supports JDK 8-14; fall back to '8' if AGP 4.1.1 misbehaves
+
+      # SDK platforms/build-tools < 34 were removed from runner images in Jan 2026 -> install explicitly
+      - name: Install Android SDK 28 components
+        run: |
+          yes | sdkmanager --licenses > /dev/null || true
+          sdkmanager "platforms;android-28" "build-tools;28.0.3"
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - name: Decode release keystore
+        env:
+          KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
+        run: |
+          if [[ -z "$KEYSTORE_BASE64" ]]; then
+            echo "::error::KEYSTORE_BASE64 secret is not set"
+            exit 1
+          fi
+          printf '%s' "$KEYSTORE_BASE64" | base64 -d > "$RUNNER_TEMP/release.keystore"
+
+      - name: Build signed release APKs
+        env:
+          VERSION_NAME: ${{ steps.ver.outputs.version_name }}
+          VERSION_CODE: ${{ steps.ver.outputs.version_code }}
+          # lowercase names below are the signing contract in aware-phone/build.gradle
+          storeFile: ${{ runner.temp }}/release.keystore
+          storePassword: ${{ secrets.KEYSTORE_PASSWORD }}
+          keyAlias: ${{ secrets.KEY_ALIAS }}
+          keyPassword: ${{ secrets.KEY_PASSWORD }}
+        run: ./gradlew :aware-phone:assembleRelease --no-daemon --stacktrace
+
+      - name: Verify 5 signed APKs
+        run: |
+          ls -l aware-phone/build/outputs/apk/release/
+          if ls aware-phone/build/outputs/apk/release/*unsigned* >/dev/null 2>&1; then
+            echo "::error::Unsigned APKs produced - signing env vars were not picked up"
+            exit 1
+          fi
+          count=$(ls aware-phone/build/outputs/apk/release/*.apk | wc -l)
+          if [[ "$count" -ne 5 ]]; then
+            echo "::error::Expected 5 ABI-split APKs, found $count"
+            exit 1
+          fi
+
+      - name: Upload workflow artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: aware-light-${{ steps.ver.outputs.version_name }}
+          path: aware-phone/build/outputs/apk/release/*.apk
+
+      - name: Create GitHub Release
+        if: github.event_name == 'push'
+        uses: softprops/action-gh-release@v2
+        with:
+          name: ${{ steps.ver.outputs.version_name }}
+          prerelease: ${{ steps.ver.outputs.prerelease == 'true' }}
+          files: aware-phone/build/outputs/apk/release/*.apk
+          fail_on_unmatched_files: true
+          generate_release_notes: true

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ aware-phone/release/*
 .DS_Store
 .DS_Store?
 local.properties
+*.jks
+*.keystore

--- a/aware-core/aware.gradle
+++ b/aware-core/aware.gradle
@@ -4,8 +4,8 @@ buildscript {
         mqtt_libs = '1.2.1'
         ion_libs = "2.+"
         google_libs = "17.0.0"
-        version_code = 3
-        version_readable = "4.7." + version_code + "." + "beta"
+        version_code = (System.getenv("VERSION_CODE") ?: "3").toInteger()
+        version_readable = System.getenv("VERSION_NAME") ?: ("4.7." + version_code + ".beta")
         compile_sdk = 28
         target_sdk = 28
         minimum_sdk = 24

--- a/aware-core/build.gradle
+++ b/aware-core/build.gradle
@@ -72,7 +72,6 @@ dependencies {
     implementation "org.eclipse.paho:org.eclipse.paho.client.mqttv3:$mqtt_libs"
     implementation 'com.koushikdutta.ion:ion:2.2.1'
     implementation 'com.google.android.material:material:1.1.0-alpha09'
-    implementation "org.jetbrains.anko:anko:$anko_version"
     implementation 'androidx.gridlayout:gridlayout:1.0.0'
     implementation 'androidx.cardview:cardview:1.0.0'
     implementation 'androidx.annotation:annotation:1.1.0'

--- a/aware-phone/build.gradle
+++ b/aware-phone/build.gradle
@@ -115,7 +115,6 @@ if (System.getenv("storeFile") != null && System.getenv("storePassword") != null
 dependencies {
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation "org.jetbrains.anko:anko:$anko_version"
 
     implementation "me.dm7.barcodescanner:zbar:1.9.8"
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,8 @@ buildscript {
         mqtt_libs = '1.2.1'
         ion_libs = "2.+"
         google_libs = "17.0.0"
-        version_code = 3
-        version_readable = "4.7." + version_code + ".beta"
+        version_code = (System.getenv("VERSION_CODE") ?: "3").toInteger()
+        version_readable = System.getenv("VERSION_NAME") ?: ("4.7." + version_code + ".beta")
 
         compile_sdk = 28
         target_sdk = 28


### PR DESCRIPTION
## What

Push a git tag to build, sign, and publish release APKs automatically:

- `4.7.4.beta` → prerelease on GitHub Releases
- `4.8.0` → stable release

Replaces the manual flow of building locally and committing APKs to `resources/`.

## Changes

- **`.github/workflows/release.yml`** (new): parses tag → builds signed `assembleRelease` (5 ABI APKs) → attaches to a GitHub Release. Fails hard if output is unsigned or APK count ≠ 5. `workflow_dispatch` = build-only smoke test.
- **`build.gradle` / `aware-core/aware.gradle`**: `version_code` / `version_readable` now read `VERSION_CODE` / `VERSION_NAME` env vars, falling back to the previous hardcoded values for local dev.
- versionCode formula: `M*100000 + m*1000 + p*10 + (stable ? 1 : 0)` — e.g. `4.7.1.beta` = 407010 < `4.7.1` = 407011, so beta→stable upgrades in place.
- Removed dangling `anko` dependency references (definition was commented out; broke clean-checkout builds).
- `.gitignore`: added `*.jks` / `*.keystore`.
