### PR TITLE
Fix bug with app based screen text filtering 

### DIFF
--- a/aware-core/src/main/java/com/aware/Applications.java
+++ b/aware-core/src/main/java/com/aware/Applications.java
@@ -307,8 +307,8 @@ public class Applications extends AccessibilityService {
                     }
                 }
 
-                currScreenText = "";
             }
+            currScreenText = "";
 
         }
 


### PR DESCRIPTION
When screen text is filtered by application, screen text is still collected to a buffer from all applications. This buffer is only emptied when the active application matches the filtering. When a matching application is encountered, the whole buffer is included on the next row of data.

This change moves the line that empties the buffer outside the if statement for filtering applications. The buffer is emptied after every capture. As far as I can see, this should not affect the rest of the workflow.